### PR TITLE
[fix]リンク遷移＋CTAセクションバグ改修(SP)

### DIFF
--- a/css/single.css
+++ b/css/single.css
@@ -18,8 +18,6 @@ body {
   line-height: 1.5;
   background-color: #0A0E10;
   color: #F2F3EE;
-  -webkit-transform: translate3d(0, 0, 0);
-          transform: translate3d(0, 0, 0);
 }
 
 img {

--- a/css/style.css
+++ b/css/style.css
@@ -19,8 +19,6 @@ body {
   line-height: 1.5;
   background-color: #0A0E10;
   color: #F2F3EE;
-  -webkit-transform: translate3d(0, 0, 0);
-          transform: translate3d(0, 0, 0);
 }
 
 img {
@@ -573,29 +571,6 @@ p {
 }
 
 /*
-右から左へ
-----------------------------*/
-@-webkit-keyframes infinity-scroll-left {
-  from {
-    -webkit-transform: translateX(0);
-            transform: translateX(0);
-  }
-  to {
-    -webkit-transform: translateX(-100%);
-            transform: translateX(-100%);
-  }
-}
-@keyframes infinity-scroll-left {
-  from {
-    -webkit-transform: translateX(0);
-            transform: translateX(0);
-  }
-  to {
-    -webkit-transform: translateX(-100%);
-            transform: translateX(-100%);
-  }
-}
-/*
 IE11対策
 ----------------------------*/
 _:-ms-lang(x)::-ms-backdrop,
@@ -633,6 +608,8 @@ _:-ms-lang(x)::-ms-backdrop,
 
 .fv-slider__list--left {
   will-change: transform;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
   -webkit-animation: infinity-scroll-left 80s infinite linear 0.5s both;
           animation: infinity-scroll-left 80s infinite linear 0.5s both;
 }
@@ -657,6 +634,29 @@ _:-ms-lang(x)::-ms-backdrop,
      object-fit: cover;
 }
 
+/*
+  右から左へ
+----------------------------*/
+@-webkit-keyframes infinity-scroll-left {
+  from {
+    -webkit-transform: translateX(0);
+            transform: translateX(0);
+  }
+  to {
+    -webkit-transform: translateX(-100%);
+            transform: translateX(-100%);
+  }
+}
+@keyframes infinity-scroll-left {
+  from {
+    -webkit-transform: translateX(0);
+            transform: translateX(0);
+  }
+  to {
+    -webkit-transform: translateX(-100%);
+            transform: translateX(-100%);
+  }
+}
 .ex-inner {
   padding-bottom: 70px;
 }

--- a/header.php
+++ b/header.php
@@ -66,10 +66,10 @@
             <a href="<?php echo esc_url(home_url( '/' )); ?>" class="header-logoArea"><img width="124" height="33" src="<?php echo get_template_directory_uri() ?>/images/Logo-white.png" alt="会社ロゴ" class="header-logoArea__icon"></a>
             <ul class="header-ul">
                 <li class="header-list">
-                    <a class="header-list__item js-ex__btn">導入事例</a>
+                    <a href="<?php echo esc_url(home_url( '/#ex' )); ?>" class="header-list__item js-ex__btn">導入事例</a>
                 </li>
                 <li class="header-list">
-                    <a class="btn whiteBtn header-list__btn js-achievement__btn"><span
+                    <a href="<?php echo esc_url(home_url( '/#contact' )); ?>" class="btn whiteBtn header-list__btn js-achievement__btn"><span
                             class="whiteBtn-text header-list__btn--text">実績を見る</span></a>
                 </li>
             </ul>

--- a/scss/foundation/_reset.scss
+++ b/scss/foundation/_reset.scss
@@ -21,7 +21,7 @@ body {
     background-color: $primary_black;
     color: $primary_white;
     // ページ内のどんなアニメーションにも対応
-    transform: translate3d(0,0,0);
+    // transform: translate3d(0,0,0);
 }
 
 img {


### PR DESCRIPTION
下記2点を改修
1、導入事例をクリックすると、問い合わせフォームに飛んでしまう
2、スマホ版、CTAセクションの動きがおかしい

【改修内容詳細】
1、aタグのhref属性の指定が抜けていたので、指定することで改修
2、body要素につけていた「transform: translate3d(0,0,0);」というプロパティを削除することで改修

ご確認お願いいたします。